### PR TITLE
feat(config): add support for dns name in rpcAddress

### DIFF
--- a/config/load.go
+++ b/config/load.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 
 	"github.com/labstack/gommon/log"
+	"github.com/warjiang/page-spy-api/util"
 )
 
 const ConfigFileName = "config.json"
@@ -32,7 +33,8 @@ func LoadConfig() (*Config, error) {
 
 	// 从环境变量加载认证配置
 	loadAuthConfigFromEnv(config)
-
+	buff, _ := json.Marshal(config)
+	fmt.Println(string(buff))
 	return config, nil
 }
 
@@ -120,5 +122,24 @@ func loadLocalConfigFile() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode config.json error %w", err)
 	}
+
+	config = resolveRpcAddress(config)
 	return config, nil
+}
+
+func resolveRpcAddress(config *Config) *Config {
+	if config == nil || config.RpcAddress == nil {
+		return config
+	}
+
+	resolvedRpcAddress := make([]*Address, 0, len(config.RpcAddress))
+	for idx, addr := range config.RpcAddress {
+		resolvedIP := util.ResolveIP(addr.Ip)
+		resolvedRpcAddress[idx] = &Address{
+			Ip:   resolvedIP,
+			Port: addr.Port,
+		}
+	}
+	config.RpcAddress = resolvedRpcAddress
+	return config
 }

--- a/util/ip.go
+++ b/util/ip.go
@@ -39,3 +39,29 @@ func GetLocalIPList() []string {
 
 	return arr
 }
+
+func IsIP(ipOrDns string) bool {
+	if ip := net.ParseIP(ipOrDns); ip != nil {
+		return true
+	}
+	return false
+}
+
+func ResolveIP(ipOrDns string) string {
+	if IsIP(ipOrDns) {
+		return ipOrDns
+	}
+	localIP := GetLocalIP()
+	ips, err := net.LookupIP(ipOrDns)
+	if err != nil {
+		return ipOrDns
+	}
+
+	for _, ip := range ips {
+		if ip.String() == localIP {
+			return localIP
+		}
+	}
+	// not found any matched ip address in ips
+	return ipOrDns
+}


### PR DESCRIPTION
## Summary by Sourcery

Enable DNS hostname support for RPC addresses by adding IP resolution utilities and integrating them into the configuration loader

Enhancements:
- Introduce IsIP and ResolveIP utilities for parsing and resolving hostnames to IP addresses
- Resolve DNS names in the RpcAddress configuration list during config loading
- Log the loaded configuration as JSON for debugging