### PR TITLE
feat(ip): random choose ip when resolve

### DIFF
--- a/config/load.go
+++ b/config/load.go
@@ -131,14 +131,13 @@ func resolveRpcAddress(config *Config) *Config {
 	if config == nil || config.RpcAddress == nil {
 		return config
 	}
-	fmt.Printf("rpc address: %+v, and len is: %d \n", config.RpcAddress, len(config.RpcAddress))
-	resolvedRpcAddress := make([]*Address, 0)
-	for _, addr := range config.RpcAddress {
+	resolvedRpcAddress := make([]*Address, len(config.RpcAddress))
+	for idx, addr := range config.RpcAddress {
 		resolvedIP := util.ResolveIP(addr.Ip)
-		resolvedRpcAddress = append(resolvedRpcAddress, &Address{
+		resolvedRpcAddress[idx] = &Address{
 			Ip:   resolvedIP,
 			Port: addr.Port,
-		})
+		}
 	}
 	config.RpcAddress = resolvedRpcAddress
 	return config

--- a/util/ip.go
+++ b/util/ip.go
@@ -1,6 +1,9 @@
 package util
 
-import "net"
+import (
+	"math/rand"
+	"net"
+)
 
 // GetLocalIP 获取本机ip 获取失败返回 ""
 func GetLocalIP() string {
@@ -63,5 +66,9 @@ func ResolveIP(ipOrDns string) string {
 		}
 	}
 	// not found any matched ip address in ips
+	if len(ips) > 0 {
+		index := rand.Intn(len(ips))
+		return ips[index].String()
+	}
 	return ipOrDns
 }


### PR DESCRIPTION
## Summary by Sourcery

Implement random selection of IPs in DNS resolution and optimize RPC address resolution by preallocating slices and removing debug output.

New Features:
- Randomly select an IP address when resolving DNS names.

Enhancements:
- Preallocate slice capacity for RPC address resolution to avoid dynamic growth.
- Remove debug printing of RPC addresses during configuration loading.