### PR TITLE
feat(config): add support for dns name in rpcAddress

### DIFF
--- a/config/load.go
+++ b/config/load.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 
 	"github.com/labstack/gommon/log"
+	"github.com/warjiang/page-spy-api/util"
 )
 
 const ConfigFileName = "config.json"
@@ -32,7 +33,6 @@ func LoadConfig() (*Config, error) {
 
 	// 从环境变量加载认证配置
 	loadAuthConfigFromEnv(config)
-
 	return config, nil
 }
 
@@ -120,5 +120,23 @@ func loadLocalConfigFile() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode config.json error %w", err)
 	}
+
+	config = resolveRpcAddress(config)
 	return config, nil
+}
+
+func resolveRpcAddress(config *Config) *Config {
+	if config == nil || config.RpcAddress == nil {
+		return config
+	}
+	resolvedRpcAddress := make([]*Address, len(config.RpcAddress))
+	for idx, addr := range config.RpcAddress {
+		resolvedIP := util.ResolveIP(addr.Ip)
+		resolvedRpcAddress[idx] = &Address{
+			Ip:   resolvedIP,
+			Port: addr.Port,
+		}
+	}
+	config.RpcAddress = resolvedRpcAddress
+	return config
 }

--- a/util/ip.go
+++ b/util/ip.go
@@ -1,6 +1,8 @@
 package util
 
-import "net"
+import (
+	"net"
+)
 
 // GetLocalIP 获取本机ip 获取失败返回 ""
 func GetLocalIP() string {
@@ -38,4 +40,30 @@ func GetLocalIPList() []string {
 	}
 
 	return arr
+}
+
+func IsIP(ipOrDns string) bool {
+	if ip := net.ParseIP(ipOrDns); ip != nil {
+		return true
+	}
+	return false
+}
+
+func ResolveIP(ipOrDns string) string {
+	if IsIP(ipOrDns) {
+		return ipOrDns
+	}
+	localIP := GetLocalIP()
+	ips, err := net.LookupIP(ipOrDns)
+	if err != nil {
+		return ipOrDns
+	}
+
+	for _, ip := range ips {
+		if ip.String() == localIP {
+			return localIP
+		}
+	}
+	// not found any matched ip address in ips
+	return ipOrDns
 }


### PR DESCRIPTION
## Summary by Sourcery

Add support for DNS names in RPCAddress by resolving hostnames to IP addresses at config load using new util functions.

New Features:
- Resolve DNS names in RPC addresses when loading config

Enhancements:
- Add util.IsIP to detect IP vs hostname and util.ResolveIP for DNS lookup
- Integrate resolveRpcAddress to apply DNS resolution to RpcAddress in config loader