### PR TITLE
fix: uniq data for multireplicas

### DIFF
--- a/data/logs.go
+++ b/data/logs.go
@@ -25,6 +25,7 @@ type Page[T OrderData] struct {
 
 type OrderData interface {
 	GetOrderValue() float64
+	GetUniqKey() string
 }
 
 func (p *Page[T]) Merge(result rpc.MergeResult) error {
@@ -44,6 +45,20 @@ func (p *Page[T]) Desc() {
 	})
 }
 
+func (p *Page[T]) UniqData() {
+	seen := make(map[string]struct{})
+	clonedData := make([]T, 0, len(p.Data))
+
+	for _, item := range p.Data {
+		itemKey := item.GetUniqKey()
+		if _, exists := seen[itemKey]; !exists {
+			seen[itemKey] = struct{}{}
+			clonedData = append(clonedData, item)
+		}
+	}
+	p.Data = clonedData
+}
+
 func (p *Page[T]) New() rpc.MergeResult {
 	return &Page[T]{}
 }
@@ -57,6 +72,10 @@ type Model struct {
 
 func (m *Model) GetOrderValue() float64 {
 	return float64(m.CreatedAt.Unix())
+}
+
+func (m *Model) GetUniqKey() string {
+	return fmt.Sprintf("%d_%d", m.ID, m.CreatedAt.Unix())
 }
 
 type LogData struct {

--- a/serve/route/core.go
+++ b/serve/route/core.go
@@ -213,6 +213,7 @@ func (c *CoreApi) GetFileList(query *data.FileListQuery) (*data.Page[*data.LogDa
 	}
 
 	res.Desc()
+	res.UniqData()
 	return res, nil
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Enforce unique items in merged pages by keying each entry and filtering out duplicates in the file list API

New Features:
- Extend OrderData with GetUniqKey and add Page.UniqData for deduplication

Bug Fixes:
- Remove duplicate entries in paginated results for multi-replica queries

Enhancements:
- Implement GetUniqKey on Model using ID and timestamp composite key