### PR TITLE
feat(storage): add support for pathStyle s3 api

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,13 +14,14 @@ type CorsConfig struct {
 }
 
 type StorageConfig struct {
-	LogDirName string `json:"logDir"`
-	BaseDir    string `json:"baseDir"`
-	KeyId      string `json:"keyId"`
-	Secret     string `json:"secret"`
-	Region     string `json:"region"`
-	Endpoint   string `json:"endpoint"`
-	Bucket     string `json:"bucket"`
+	LogDirName       string `json:"logDir"`
+	BaseDir          string `json:"baseDir"`
+	KeyId            string `json:"keyId"`
+	Secret           string `json:"secret"`
+	Region           string `json:"region"`
+	Endpoint         string `json:"endpoint"`
+	Bucket           string `json:"bucket"`
+	S3ForcePathStyle bool   `json:"s3ForcePathStyle"`
 }
 
 func (s *StorageConfig) GetLogDir() string {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -25,9 +25,10 @@ func (a *RemoteApi) joinPath(id string) string {
 func (a *RemoteApi) newSession() (*session.Session, error) {
 	config := a.config
 	session, err := session.NewSession(&aws.Config{
-		Region:      aws.String(config.Region),
-		Credentials: credentials.NewStaticCredentials(config.KeyId, config.Secret, ""),
-		Endpoint:    aws.String(config.Endpoint),
+		Region:           aws.String(config.Region),
+		Credentials:      credentials.NewStaticCredentials(config.KeyId, config.Secret, ""),
+		Endpoint:         aws.String(config.Endpoint),
+		S3ForcePathStyle: aws.Bool(config.S3ForcePathStyle),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sessionion: %w", err)


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add S3ForcePathStyle flag to StorageConfig and apply it to AWS S3 client sessions to enable path-style addressing.